### PR TITLE
Mark form as clean if initial values are restored

### DIFF
--- a/dist/jquery.dirty.js
+++ b/dist/jquery.dirty.js
@@ -168,7 +168,7 @@
 
         checkValues: function(e) {
             var d = this;
-            var formIsDirty = d.isDirty;
+            var formIsDirty = false;
 
             this.form.find("input, select, textarea").each(function(_, el) {
                 var isRadioOrCheckbox = d.isRadioOrCheckbox(el);

--- a/test/test.js
+++ b/test/test.js
@@ -104,6 +104,33 @@ QUnit.test("form is marked as clean when setAsClean is called", function(assert)
   assert.ok(onCleanCalledCount === 1, "onClean was called");
 });
 
+QUnit.test("form is marked as clean when changes are reverted", function(assert){
+  // Arrange
+  var $form = $("#testForm");
+  var onCleanCalledCount = 0;
+  var options = {
+    onClean: function(){
+      onCleanCalledCount++;
+    },
+    fireEventsOnEachChange: false
+  };
+  $form.dirty(options);
+
+  // dirty the form
+  var $input = $form.find("input:first");
+  $input.val("test");
+  $input.trigger("change");
+
+  // Act I
+  $input.val("");
+  $input.trigger("change");
+
+  // Assert
+  assert.ok($form.dirty("isClean") === true, "form is clean when resetForm called");
+  assert.ok($form.dirty("isDirty") === false, "form is not dirty when resetForm called");
+  assert.ok(onCleanCalledCount === 1, "onClean was called");
+});
+
 QUnit.test("form is marked as clean when resetForm is called", function(assert){
   // Arrange
   var $form = $("#testForm");


### PR DESCRIPTION
The previous logic would never set a form as clean again.

Maybe related to https://github.com/simontaite/jquery.dirty/issues/11.